### PR TITLE
feat(swagger): ajout de la doc Swagger complète avec JWT et DTOs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.4.17",
+        "@nestjs/swagger": "^7.4.2",
         "@nestjs/typeorm": "^11.0.0",
         "@types/passport-jwt": "^4.0.1",
         "aws-sdk": "^2.1692.0",
@@ -36,6 +37,7 @@
         "pg": "^8.13.2",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.1",
         "typeorm": "^0.3.20"
       },
       "devDependencies": {
@@ -2481,6 +2483,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw=="
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.4.8",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.8.tgz",
@@ -2784,6 +2791,57 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.2.tgz",
+      "integrity": "sha512-Mu6TEn1M/owIvAx2B4DUQObQXqo2028R2s9rSZ/hJEgBK95+doTwS0DjmVA2wTeZTyVtXOoN7CsoM5pONBzvKQ==",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.15.0",
+        "@nestjs/mapped-types": "2.0.5",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.3.0",
+        "swagger-ui-dist": "5.17.14"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.13",
@@ -4707,7 +4765,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -8719,7 +8776,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8989,7 +9045,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
@@ -11312,6 +11367,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.4.17",
+    "@nestjs/swagger": "^7.4.2",
     "@nestjs/typeorm": "^11.0.0",
     "@types/passport-jwt": "^4.0.1",
     "aws-sdk": "^2.1692.0",
@@ -50,6 +51,7 @@
     "pg": "^8.13.2",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.20"
   },
   "devDependencies": {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,18 +1,31 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { AppService } from './app.service';
 import { AuthGuard } from '@nestjs/passport';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 
+@ApiTags('app')
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get('health-check')
+  @ApiOperation({ summary: 'Vérifie que l\'application est en ligne' })
+  @ApiResponse({ status: 200, description: 'Application en ligne' })
   getHello(): string {
     return this.appService.getHello();
   }
 
   @UseGuards(AuthGuard('jwt'))
   @Get('ping')
+  @ApiBearerAuth('jwt-auth')
+  @ApiOperation({ summary: 'Endpoint ping sécurisé' })
+  @ApiResponse({ status: 200, description: 'Réponse Pong si authentifié' })
+  @ApiResponse({ status: 401, description: 'Non autorisé' })
   ping(): string {
     return 'Pong';
   }

--- a/src/common/dto/http-request.dto.ts
+++ b/src/common/dto/http-request.dto.ts
@@ -1,8 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserCredentialsDto {
+  @ApiProperty({ description: 'Identifiant unique de l’utilisateur' })
+  userId: string;
+
+  @ApiProperty({ type: [String], description: 'Groupes ou rôles de l’utilisateur' })
+  groups: string[];
+}
+
 export class HttpRequestDto extends Request {
+  @ApiProperty({ type: UserCredentialsDto })
   user: UserCredentialsDto;
 }
 
-export class UserCredentialsDto {
-  userId: string;
-  groups: string[];
-}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import * as dotenv from 'dotenv';
 import { BadRequestException, ValidationPipe } from '@nestjs/common';
@@ -34,6 +35,25 @@ async function bootstrap() {
   });
 
   app.setGlobalPrefix('api');
+
+  const config = new DocumentBuilder()
+      .setTitle('API')
+      .setDescription('The routes API description')
+      .setVersion('1.0')
+      .addBearerAuth(
+          {
+            type: 'http',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+            name: 'Authorization',
+            in: 'header',
+          },
+          'jwt-auth', // nom du security scheme
+      )
+      .build();
+  const documentFactory = () => SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, documentFactory);
+
   await app.listen(8080, '0.0.0.0');
 }
 bootstrap();

--- a/src/modules/booster/booster.controller.ts
+++ b/src/modules/booster/booster.controller.ts
@@ -2,13 +2,30 @@ import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
 import { BoosterService } from './booster.service';
 import { AuthGuard } from '@nestjs/passport';
 import { HttpRequestDto } from '../../common/dto/http-request.dto';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 
+@ApiTags('booster')
+@ApiBearerAuth('jwt-auth')
 @Controller('booster')
 @UseGuards(AuthGuard('jwt'))
 export class BoosterController {
   public constructor(private readonly boosterService: BoosterService) {}
 
   @Get(':count')
+  @ApiOperation({ summary: 'Récupère un booster avec un nombre donné' })
+  @ApiParam({
+    name: 'count',
+    type: Number,
+    description: 'Nombre de boosters à récupérer',
+  })
+  @ApiResponse({ status: 200, description: 'Booster récupéré avec succès' })
+  @ApiResponse({ status: 400, description: 'Paramètre count invalide' })
   public getBooster(
     @Param('count') amount: string,
     @Req() req: HttpRequestDto,

--- a/src/modules/profile/dto/update-profile.dto.ts
+++ b/src/modules/profile/dto/update-profile.dto.ts
@@ -16,29 +16,38 @@ import {
   SmokingEnum,
   ZodiacEnum,
 } from '../enums';
+import { ApiProperty } from '@nestjs/swagger';
+import {Type} from "class-transformer";
 
 class PersonalInfo {
   @IsString()
+  @ApiProperty()
   name: string;
 
   @IsString()
+  @ApiProperty()
   surname: string;
 
   @IsNumber()
+  @ApiProperty()
   age: number;
 
   @IsEnum(GenderEnum)
+  @ApiProperty()
   gender: GenderEnum;
 
   @IsEnum(OrientationEnum)
+  @ApiProperty()
   orientation: OrientationEnum;
 }
 
 class LocationWorkInfo {
   @IsString()
+  @ApiProperty()
   city: string;
 
   @IsString()
+  @ApiProperty()
   work: string;
 
   @IsString({ each: true })
@@ -47,12 +56,15 @@ class LocationWorkInfo {
 
 class PreferenceInfo {
   @IsNumber()
+  @ApiProperty()
   min_age: number;
 
   @IsNumber()
+  @ApiProperty()
   max_age: number;
 
   @IsNumber()
+  @ApiProperty()
   max_distance: number;
 
   @IsEnum(RelationshipTypeEnum)
@@ -61,17 +73,21 @@ class PreferenceInfo {
 
 class LifestyleInfo {
   @IsEnum(SmokingEnum)
+  @ApiProperty()
   smoking: SmokingEnum;
 
   @IsEnum(DrinkingEnum)
+  @ApiProperty()
   drinking: DrinkingEnum;
 
   @IsOptional()
   @IsEnum(ReligionEnum)
+  @ApiProperty()
   religion: ReligionEnum;
 
   @IsOptional()
   @IsEnum(PoliticsEnum)
+  @ApiProperty()
   politics: PoliticsEnum;
 
   @IsOptional()
@@ -81,19 +97,28 @@ class LifestyleInfo {
 
 export class UpdateProfileDto {
   @ValidateNested()
+  @Type(() => PersonalInfo)
+  @ApiProperty({ type: PersonalInfo })
   personalInfo: PersonalInfo;
 
   @ValidateNested()
+  @Type(() => PreferenceInfo)
+  @ApiProperty({ type: PreferenceInfo })
   preferenceInfo: PreferenceInfo;
 
   @ValidateNested()
+  @Type(() => LocationWorkInfo)
+  @ApiProperty({ type: LocationWorkInfo })
   locationWork: LocationWorkInfo;
 
   @ValidateNested()
+  @Type(() => LifestyleInfo)
+  @ApiProperty({ type: LifestyleInfo })
   lifestyleInfo: LifestyleInfo;
 
   @IsOptional()
-  @IsString()
+  @IsString({ each: true })
+  @ApiProperty({ type: [String], required: false })
   interests?: string[];
 }
 

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -21,18 +21,42 @@ import { UpdateProfileDto } from './dto/update-profile.dto';
 import { Profile } from '../../common/entities/profile.entity';
 import { ProfileService } from './services/profile.service';
 import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 
 @UseGuards(AuthGuard('jwt'))
+@ApiBearerAuth('jwt-auth')
+@ApiTags('profiles')
 @Controller('profiles')
 export class ProfileController {
   constructor(private readonly profileService: ProfileService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Récupère le profil de l’utilisateur connecté' })
+  @ApiResponse({ status: 200, description: 'Profil récupéré avec succès' })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - jeton JWT manquant ou invalide',
+  })
   public async getProfile(@Req() req: HttpRequestDto) {
     return this.profileService.getProfile(req);
   }
 
   @Put()
+  @ApiOperation({ summary: 'Met à jour le profil complet de l’utilisateur' })
+  @ApiBody({ type: UpdateProfileDto })
+  @ApiResponse({ status: 200, description: 'Profil mis à jour avec succès' })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - jeton JWT manquant ou invalide',
+  })
   public async updateProfile(
     @Req() req: HttpRequestDto,
     @Body() body: UpdateProfileDto,
@@ -41,6 +65,25 @@ export class ProfileController {
   }
 
   @Put(':userId/interests')
+  @ApiOperation({ summary: 'Met à jour les centres d’intérêt d’un utilisateur' })
+  @ApiParam({ name: 'userId', type: String, description: 'ID de l’utilisateur' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+      required: ['data'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Intérêts mis à jour avec succès', type: Profile })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - jeton JWT manquant ou invalide',
+  })
   public async updateProfileInterests(
     @Param('userId') userId: string,
     @Body() body: { data: string[] },
@@ -49,6 +92,13 @@ export class ProfileController {
   }
 
   @Post()
+  @ApiOperation({ summary: 'Crée un nouveau profil pour l’utilisateur connecté' })
+  @ApiBody({ type: UpdateProfileDto })
+  @ApiResponse({ status: 201, description: 'Profil créé avec succès' })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - jeton JWT manquant ou invalide',
+  })
   public async createProfile(
     @Req() req: HttpRequestDto,
     @Body() body: UpdateProfileDto,
@@ -68,6 +118,29 @@ export class ProfileController {
   // returning only the object URL
   @Put('image/:index')
   @UseInterceptors(FileInterceptor('image'))
+  @ApiOperation({ summary: 'Upload une image de profil à un index donné' })
+  @ApiParam({
+    name: 'index',
+    type: Number,
+    description: 'Index de l’image (0 à 5)',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        image: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Image uploadée avec succès' })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - jeton JWT manquant ou invalide',
+  })
   public async uploadImage(
     @Param(
       'index',
@@ -87,6 +160,17 @@ export class ProfileController {
   }
 
   @Delete('image/:index')
+  @ApiOperation({ summary: 'Supprime une image de profil à un index donné' })
+  @ApiParam({
+    name: 'index',
+    type: Number,
+    description: 'Index de l’image (0 à 5)',
+  })
+  @ApiResponse({ status: 200, description: 'Image supprimée avec succès' })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - jeton JWT manquant ou invalide',
+  })
   public async deleteImage(
     @Param(
       'index',

--- a/src/modules/settings/settings.controller.ts
+++ b/src/modules/settings/settings.controller.ts
@@ -1,9 +1,14 @@
 import { Controller, Get } from '@nestjs/common';
 import { AuthSettingsDto } from './dto/auth-settings.dto';
+import {ApiOkResponse, ApiOperation, ApiTags} from "@nestjs/swagger";
 
+@ApiTags('settings')
 @Controller('settings')
 export class SettingsController {
   @Get('auth')
+  @ApiOperation({ summary: 'Récupère la configuration d’authentification Cognito' })
+  @ApiOkResponse({ description: 'Configuration renvoyée avec succès' })
+
   public getAuthConfig(): AuthSettingsDto {
     return {
       userPool: process.env.COGNITO_USER_POOL,


### PR DESCRIPTION
Modification du main.ts pour la config swagger selon la doc.
Ajout de tous les champs requis (API->Tags/BearerAuth/Operation/Response/etc) dans tous les controllers et les DTO.
Permet que le swagger soit parfaitement générer et gérer lorsque on se rends sur:
 http://localhost:8080/api#/
Dites moi vos retours pour modifications 
Toutes les modifications sont dans :
-main.ts
-*.controller.ts 
-*.dto.ts
Dependances dans le package json