### PR TITLE
Change docs for api in swagger setup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ async function bootstrap() {
       )
       .build();
   const documentFactory = () => SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, documentFactory);
+  SwaggerModule.setup('docs', app, documentFactory);
 
   await app.listen(8080, '0.0.0.0');
 }


### PR DESCRIPTION
THe example of swagger usage at /api/docs instead of /api/api